### PR TITLE
fix: using can have expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -238,7 +238,7 @@ module.exports = grammar({
 
     using_statement: $ => seq(
         alias('using', $.keyword),
-        $.identifier,
+        $._expression,
     ),
 
     return_statement: $ => prec.right(seq(

--- a/test/corpus/control_flow.txt
+++ b/test/corpus/control_flow.txt
@@ -284,3 +284,37 @@ main :: proc () {
             (operator)
             rhs: (int_literal))
           body: (block))))))
+
+================================================================================
+Using statement
+================================================================================
+
+package using_stmt
+
+main :: proc () {
+    using foo.bar
+    return bar
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (package_clause
+    (keyword)
+    (package_identifier))
+  (const_declaration
+    name: (const_identifier)
+    (operator)
+    (operator)
+    value: (proc_literal
+      (keyword)
+      parameters: (parameter_list)
+      (block
+        (using_statement
+          (keyword)
+          (selector_expression
+            parent: (identifier)
+            field: (identifier)))
+        (return_statement
+          (keyword)
+          value: (identifier))))))


### PR DESCRIPTION
At the moment, only an identifier can be there after the 'using' keyword, but multiple different expressions are legal.